### PR TITLE
Add PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  UV_VERSION: 0.9.26
+  UV_VERSION: 0.10.11
   PYTHON_VERSION: 3.12
 
 jobs:
@@ -25,12 +25,12 @@ jobs:
     needs: [tests]
     steps:
       - name: Checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up uv and Python
-        uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b  # v7.2.0
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
         with:
           version: "${{ env.UV_VERSION }}"
           python-version: ${{ env.PYTHON_VERSION }}
@@ -130,7 +130,7 @@ jobs:
       release_body: "${{ steps.git-cliff.outputs.content }}"
     steps:
       - name: Checkout the Repository at the Tagged Commit
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
           ref: "${{ github.ref_name }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,169 @@
+name: Publish simple-venn to PyPI
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+# Ensure only one publish workflow runs at a time
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  UV_VERSION: 0.9.26
+  PYTHON_VERSION: 3.12
+
+jobs:
+  tests:
+    name: Static Analysis Checks
+    uses: "./.github/workflows/python_package.yml"
+
+  build:
+    name: Build Package
+    runs-on: ubuntu-latest
+    needs: [tests]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Set up uv and Python
+        uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b  # v7.2.0
+        with:
+          version: "${{ env.UV_VERSION }}"
+          python-version: ${{ env.PYTHON_VERSION }}
+          enable-cache: 'true'
+          cache-suffix: ${{ env.PYTHON_VERSION }}
+
+      - name: Build sdist and wheel
+        run: |
+          uv build --sdist --wheel
+
+      - name: List built artifacts
+        run: |
+          ls -la dist/
+
+      - name: Verify package metadata
+        run: |
+          uv run --with twine twine check dist/*
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+          retention-days: 30
+
+  publish-testpypi:
+    name: Publish to TestPyPI
+    runs-on: ubuntu-latest
+    needs: [build]
+
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/${{ github.event.repository.name }}
+
+    # Required for PyPI Trusted Publishing
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
+        with:
+          name: dist
+          path: dist/
+
+      - name: List artifacts to publish
+        run: |
+          echo "Publishing the following artifacts to TestPyPI:"
+          ls -la dist/
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # v1.13.0
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          print-hash: true
+          verbose: true
+
+  publish-pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: [publish-testpypi]
+
+    environment:
+      name: pypi  # Requires manual approval if configured
+      url: https://pypi.org/p/${{ github.event.repository.name }}
+
+    # Required for PyPI Trusted Publishing (OIDC)
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
+        with:
+          name: dist
+          path: dist/
+
+      - name: List artifacts to publish
+        run: |
+          echo "Publishing the following artifacts to PyPI:"
+          ls -la dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # v1.13.0
+        with:
+          print-hash: true
+          verbose: true
+
+  make-changelog:
+    name: Draft Changelog
+    runs-on: ubuntu-latest
+    needs: [publish-pypi]
+    outputs:
+      release_body: "${{ steps.git-cliff.outputs.content }}"
+    steps:
+      - name: Checkout the Repository at the Tagged Commit
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+        with:
+          fetch-depth: 0
+          ref: "${{ github.ref_name }}"
+
+      - name: Generate a Changelog
+        uses: orhun/git-cliff-action@e16f179f0be49ecdfe63753837f20b9531642772  # v4.7.0
+        id: git-cliff
+        with:
+          config: pyproject.toml
+          args: --latest --verbose
+        env:
+          GITHUB_REPO: "${{ github.repository }}"
+
+  make-github-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    environment: github
+    permissions:
+      contents: write
+    needs: make-changelog
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
+        with:
+          name: dist
+          path: dist/
+
+      - name: Create GitHub Release
+        id: create_release
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2.5.0
+        with:
+          name: '${{ github.ref_name }}'
+          body: '${{ needs.make-changelog.outputs.release_body }}'
+          draft: false
+          prerelease: false
+          files: "dist/*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,3 +157,32 @@ force-single-line = true
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
+
+[tool.git-cliff.changelog]
+header = ""
+trim   = true
+body   = """
+{% for group, commits in commits | group_by(attribute="group") %}
+    ## {{ group | upper_first }}
+    {% for commit in commits %}
+        - {{ commit.message | upper_first }} ({{ commit.id | truncate(length=8, end="") }})\
+    {% endfor %}
+{% endfor %}\n
+"""
+
+[tool.git-cliff.git]
+conventional_commits = true
+commit_parsers       = [
+    { message = "^.+!:*", group = "Breaking" },
+    { message = "^feat*", group = "Features" },
+    { message = "^fix*", group = "Bug Fixes" },
+    { message = "^docs*", group = "Documentation" },
+    { message = "^perf*", group = "Performance" },
+    { message = "^refactor*", group = "Refactor" },
+    { message = "^style*", group = "Styling" },
+    { message = "^test*", group = "Testing" },
+    { message = "^chore\\(release\\):*", skip = true },
+    { message = "^chore*", group = "Miscellaneous Tasks" },
+    { body = ".*security", group = "Security" },
+]
+filter_commits       = false


### PR DESCRIPTION
## Summary
- Add publish workflow triggered on semver tags: tests → build → TestPyPI → PyPI → changelog → GitHub release
- Add git-cliff config for conventional commit changelog generation
- Action versions pinned to match CI workflow (uv 0.10.11, checkout v6.0.2, setup-uv v7.6.0)

## Test plan
- [ ] Workflow YAML is valid (check Actions tab after push)
- [ ] git-cliff config parses correctly
- [ ] End-to-end publish tested after PyPI trusted publishing is configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)