### PR TITLE
chore(release): bump to 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name            = "simple-venn"
-version         = "0.2.0-dev"
+version         = "0.2.0"
 description     = "Simple Venn diagrams"
 readme          = "README.md"
 authors         = [{ name = "Matthew Stone" }]

--- a/uv.lock
+++ b/uv.lock
@@ -774,7 +774,7 @@ wheels = [
 
 [[package]]
 name = "simple-venn"
-version = "0.2.0.dev0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib" },


### PR DESCRIPTION
## Summary
- Bump version from `0.2.0-dev` to `0.2.0` for release

## Release notes

This release modernizes the project build and tooling:

- **Build**: Migrate from `setup.py` to `pyproject.toml` with hatchling build backend and uv for dependency management
- **CI**: Add GitHub Actions workflow testing Python 3.12 & 3.13
- **Publish**: Add PyPI publish workflow with TestPyPI validation, changelog generation (git-cliff), and GitHub releases
- **Code quality**: Add ruff (formatting + linting), mypy (strict type checking), and pytest
- **Type safety**: Add type annotations to all public functions; export `SubsetValue` type alias
- **Fixes**: Fix `Ellipse` constructor for matplotlib > 3.5 compatibility
- **Docs**: Add `CONTRIBUTING.md` and `CLAUDE.md`

## After merge
1. `git tag 0.2.0` on the merge commit
2. `git push origin 0.2.0` to trigger the publish workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)